### PR TITLE
Fixing a rounding issue when converting to Julian date

### DIFF
--- a/Migration/SQLServer/2B_ExportSourceDataToParquet/Export-ParquetSharp.ps1
+++ b/Migration/SQLServer/2B_ExportSourceDataToParquet/Export-ParquetSharp.ps1
@@ -151,7 +151,7 @@ Function Get-Int96Pieces {
             $Month = $Month + 12;
             $Year = $Year - 1;
         }
-        $c = [math]::Floor($Day + (153 * $Month - 457) / 5 + 365 * $Year + ($Year / 4) - ($Year / 100) + ($Year / 400) + 1721119)
+        $c = $Day + [math]::Floor((153 * $Month - 457) / 5) + 365 * $Year + [math]::Floor($Year / 4) - [math]::Floor($Year / 100) + [math]::Floor($Year / 400) + 1721119
     } else {
         $c = 2440589    # 1/2/1970 constant
     }


### PR DESCRIPTION
There is an issue with the division operations when converting to a Julian date. To achieve the equivalent of integer division, we need to floor each operation. At the moment, the code rounds after the entire calculation. Converting dates in July 2023 moves them one day forward (e.g. 2023-07-01 becomes 2023-07-02).